### PR TITLE
Add clang-format & format code script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,107 @@
+# please use clang-format version 8 or later
+
+Standard: Cpp11
+AccessModifierOffset: -8
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+#AllowAllArgumentsOnNextLine: false  # requires clang-format 9
+#AllowAllConstructorInitializersOnNextLine: false  # requires clang-format 9
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+#AllowShortLambdasOnASingleLine: Inline  # requires clang-format 9
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: false  # apparently unpredictable
+ColumnLimit: 80
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+FixNamespaceComments: false
+ForEachMacros: 
+  - 'json_object_foreach'
+  - 'json_object_foreach_safe'
+  - 'json_array_foreach'
+IncludeBlocks: Preserve
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+#ObjCBinPackProtocolList: Auto  # requires clang-format 7
+ObjCBlockIndentWidth: 8
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+#SpaceAfterLogicalNot: false  # requires clang-format 9
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCtorInitializerColon: true  # requires clang-format 7
+#SpaceBeforeInheritanceColon: true  # requires clang-format 7
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true  # requires clang-format 7
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#StatementMacros:  # requires clang-format 8
+#  - 'Q_OBJECT'
+TabWidth: 8
+#TypenameMacros:  # requires clang-format 9
+#  - 'DARRAY'
+UseTab: ForContinuationAndIndentation
+---
+Language: ObjC

--- a/formatcode.sh
+++ b/formatcode.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Original source https://github.com/Project-OSRM/osrm-backend/blob/master/scripts/format.sh
+
+set +x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Runs the Clang Formatter in parallel on the code base.
+# Return codes:
+#  - 1 there are files to be formatted
+#  - 0 everything looks fine
+
+# Get CPU count
+OS=$(uname)
+NPROC=1
+if [[ $OS = "Linux" || $OS = "Darwin" ]] ; then
+    NPROC=$(getconf _NPROCESSORS_ONLN)
+fi
+
+# Discover clang-format
+if type clang-format-10 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-10
+elif type clang-format-8 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-8
+else
+    CLANG_FORMAT=clang-format
+fi
+
+find . -type d \( -path ./deps \
+-o -path ./release
+-o -path ./debug
+-o -path ./build \) -prune -type f -o -name '*.h' -or -name '*.hpp' -or -name '*.m' -or -name '*.mm' -or -name '*.c' -or -name '*.cpp' \
+| xargs -L100 -P${NPROC} ${CLANG_FORMAT} -i -style=file  -fallback-style=none


### PR DESCRIPTION
### Description
Allows plugin developers to easily format code.

### Motivation and Context
Makes code look nicer.

### How Has This Been Tested?
Ran script and made sure everything was formatted properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
