### PR TITLE
Refactor find_qt CMake macro to select Qt version automatically if not specified

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -3,7 +3,6 @@
       "find_qt": {
         "flags": [],
         "kwargs": {
-          "VERSION": "+",
           "COMPONENTS": "+",
           "COMPONENTS_WIN": "+",
           "COMPONENTS_MACOS": "+",

--- a/.github/scripts/utils.zsh/check_macos
+++ b/.github/scripts/utils.zsh/check_macos
@@ -16,7 +16,5 @@ if (( ! ${+commands[brew]} )) {
   return 2
 }
 
-# Temporary GitHub Actions fix
-if (( ${+CI} )) brew unlink git@2.35.1
-brew bundle --file "${SCRIPT_HOME}/.Brewfile"
+brew bundle --file "${SCRIPT_HOME}/.Brewfile" --no-upgrade
 rehash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.c)
 find_package(libobs REQUIRED)
 find_package(obs-frontend-api REQUIRED)
 include(cmake/ObsPluginHelpers.cmake)
-find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets Core)
+find_qt(COMPONENTS Widgets Core)
 
 configure_file(src/plugin-macros.h.in
                ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.h)

--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -54,43 +54,98 @@ endif()
 
 if(NOT QT_VERSION)
   set(QT_VERSION
-      "5"
-      CACHE STRING "OBS Qt version [5, 6]" FORCE)
-  set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
+      AUTO
+      CACHE STRING "OBS Qt version [AUTO, 5, 6]" FORCE)
+  set_property(CACHE QT_VERSION PROPERTY STRINGS AUTO 5 6)
 endif()
 
 macro(find_qt)
-  set(oneValueArgs VERSION)
   set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC COMPONENTS_LINUX)
   cmake_parse_arguments(FIND_QT "" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
+  set(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
+  find_package(
+    Qt5
+    COMPONENTS Core
+    QUIET)
+  find_package(
+    Qt6
+    COMPONENTS Core
+    QUIET)
+
+  if(NOT _QT_VERSION AND QT_VERSION STREQUAL AUTO)
+    if(TARGET Qt6::Core)
+      set(_QT_VERSION
+          6
+          CACHE INTERNAL "")
+    elseif(TARGET Qt5::Core)
+      set(_QT_VERSION
+          5
+          CACHE INTERNAL "")
+    endif()
+    message(STATUS "Qt version: ${_QT_VERSION}")
+  elseif(NOT _QT_VERSION)
+    if(TARGET Qt${QT_VERSION}::Core)
+      set(_QT_VERSION
+          ${QT_VERSION}
+          CACHE INTERNAL "")
+    else()
+      if(QT_VERSION EQUAL 6)
+        set(FALLBACK_QT_VERSION 5)
+      else()
+        set(FALLBACK_QT_VERSION 6)
+      endif()
+      message(
+        WARNING
+          "Qt${QT_VERSION} was not found, falling back to Qt${FALLBACK_QT_VERSION}"
+      )
+
+      if(TARGET Qt${FALLBACK_QT_VERSION}::Core)
+        set(_QT_VERSION
+            ${FALLBACK_QT_VERSION}
+            CACHE INTERNAL "")
+      endif()
+    endif()
+    message(STATUS "Qt version: ${_QT_VERSION}")
+  endif()
+
+  set(QT_NO_CREATE_VERSIONLESS_TARGETS OFF)
+
+  if(NOT _QT_VERSION)
+    message(FATAL_ERROR "Neither Qt5 or Qt6 were found")
+  endif()
 
   if(OS_WINDOWS)
     find_package(
-      Qt${FIND_QT_VERSION}
+      Qt${_QT_VERSION}
       COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_WIN}
       REQUIRED)
   elseif(OS_MACOS)
     find_package(
-      Qt${FIND_QT_VERSION}
+      Qt${_QT_VERSION}
       COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_MAC}
       REQUIRED)
   else()
     find_package(
-      Qt${FIND_QT_VERSION}
+      Qt${_QT_VERSION}
       COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_LINUX}
       REQUIRED)
   endif()
 
+  list(APPEND FIND_QT_COMPONENTS "Core")
+
+  if("Gui" IN_LIST FIND_QT_COMPONENTS_LINUX)
+    list(APPEND FIND_QT_COMPONENTS_LINUX "GuiPrivate")
+  endif()
+
   foreach(_COMPONENT IN LISTS FIND_QT_COMPONENTS FIND_QT_COMPONENTS_WIN
                               FIND_QT_COMPONENTS_MAC FIND_QT_COMPONENTS_LINUX)
-    if(NOT TARGET Qt::${_COMPONENT} AND TARGET
-                                        Qt${FIND_QT_VERSION}::${_COMPONENT})
+    if(NOT TARGET Qt::${_COMPONENT} AND TARGET Qt${_QT_VERSION}::${_COMPONENT})
 
       add_library(Qt::${_COMPONENT} INTERFACE IMPORTED)
       set_target_properties(
         Qt::${_COMPONENT} PROPERTIES INTERFACE_LINK_LIBRARIES
-                                     "Qt${FIND_QT_VERSION}::${_COMPONENT}")
+                                     "Qt${_QT_VERSION}::${_COMPONENT}")
     endif()
   endforeach()
 endmacro()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Same changes as https://github.com/obsproject/obs-studio/pull/6782 but for the template.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Allow to automatically use whether Qt5 or Qt6 is available and if both are present **prefer Qt6**.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

https://github.com/obsproject/obs-studio/pull/6782 proves that the macro is functional.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
