### PR TITLE
Ignore build_x86_64/release dirs in format scripts

### DIFF
--- a/.github/scripts/check-cmake.sh
+++ b/.github/scripts/check-cmake.sh
@@ -36,7 +36,8 @@ if ! type cmake-format 2> /dev/null ; then
 fi
 
 find . -type d \( \
-    -path ./\*build -o \
+    -path ./\*build\* -o \
+    -path ./release -o \
     -path ./deps/jansson -o \
     -path ./plugins/decklink/\*/decklink-sdk -o \
     -path ./plugins/enc-amf -o \

--- a/.github/scripts/check-format.sh
+++ b/.github/scripts/check-format.sh
@@ -42,7 +42,8 @@ else
 fi
 
 find . -type d \( \
-    -path ./\*build -o \
+    -path ./\*build\* -o \
+    -path ./release -o \
     -path ./cmake -o \
     -path ./plugins/decklink/\*/decklink-sdk -o \
     -path ./plugins/enc-amf -o \


### PR DESCRIPTION
### Description
The scripts would fail if these directories were present.

### Motivation and Context
Found when formatting plugin.

### How Has This Been Tested?
Ran script to see if it didn't fail

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
