### PR TITLE
Update buildspec to use Qt6 on Linux

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -75,7 +75,7 @@
             "platformSDK": "10.0.18363.657"
         },
         "linux-x86_64": {
-            "qtVersion": 5
+            "qtVersion": 6
         }
     },
     "name": "obs-plugintemplate",


### PR DESCRIPTION
### Description
Use Qt6 by default

### Motivation and Context
Since most developers will be using newer Linux and targeting OBS 28, default to Qt6

### How Has This Been Tested?
Building plugin

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
