### PR TITLE
Disable the "Directory already exists" warning in Windows installer

### DIFF
--- a/cmake/bundle/windows/installer-Windows.iss.in
+++ b/cmake/bundle/windows/installer-Windows.iss.in
@@ -19,6 +19,7 @@ DefaultGroupName={#MyAppName}
 OutputBaseFilename={#MyAppName}-{#MyAppVersion}-Windows-Installer
 Compression=lzma
 SolidCompression=yes
+DirExistsWarning=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
### Description
Because of course the directory exists, it's a plugin.

### Motivation and Context
Don't want confusing dialogs popping up to users

### How Has This Been Tested?
Used in obs-websocket

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
