### PR TITLE
Set LINUX_PORTABLE to off on CI

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -220,7 +220,7 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
         ;;
       linux-*)
         if (( ${+CI} )) {
-          cmake_args+=(-DCMAKE_INSTALL_PREFIX=/usr)
+          cmake_args+=(-DCMAKE_INSTALL_PREFIX=/usr -DLINUX_PORTABLE=OFF)
         }
         num_procs=$(( $(nproc) + 1 ))
         ;;


### PR DESCRIPTION
### Description
This matches what is default in OBS Studio. Most developers won't
know to change this, as the deb file will install to the wrong place,
causing the plugin not to load.

### Motivation and Context
Got frustrated when installing the deb file, and the plugin wouldn't load. Found out LINUX_PORTABLE was set to ON.

### How Has This Been Tested?
Installed via deb and the plugin loaded successfully.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
