### PR TITLE
Move UUIDs to CMakeLists.txt

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -180,14 +180,22 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
 
   case ${host_os} {
     macos)
+      local MACOS_PACKAGE_UUID
+      local MACOS_INSTALLER_UUID
+      read -r MACOS_PACKAGE_UUID MACOS_INSTALLER_UUID <<< \
+        "$(jq -r '. | {"macosPackageUuid", "macosInstallerUuid"} | join(" ")' ${buildspec_file})"
       sed -i '' \
-        "s/project(\(.*\) VERSION \(.*\))/project(${product_name} VERSION ${product_version})/" \
+        -e "s/project(\(.*\) VERSION \(.*\))/project(${product_name} VERSION ${product_version})/" \
         "${project_root}/CMakeLists.txt"
       sed -i '' \
         "s/set(PLUGIN_AUTHOR \(.*\))/set(PLUGIN_AUTHOR ${product_author})/"\
         "${project_root}/CMakeLists.txt"
       sed -i '' \
         "s/set(LINUX_MAINTAINER_EMAIL \(.*\))/set(LINUX_MAINTAINER_EMAIL ${product_email})/"\
+        "${project_root}/CMakeLists.txt"
+      sed -i '' \
+        -e "s/set(MACOS_PACKAGE_UUID \(.*\))/set(MACOS_PACKAGE_UUID \"${MACOS_PACKAGE_UUID}\")/" \
+        -e "s/set(MACOS_INSTALLER_UUID \(.*\))/set(MACOS_INSTALLER_UUID \"${MACOS_INSTALLER_UUID}\")/" \
         "${project_root}/CMakeLists.txt"
       ;;
     linux)

--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -45,6 +45,7 @@ function Build {
     $BuildSpec = Get-Content -Path ${BuildSpecFile} -Raw | ConvertFrom-Json
     $ProductName = $BuildSpec.name
     $ProductVersion = $BuildSpec.version
+    $AppId = $BuildSpec."windowsAppId"
 
     $script:DepsVersion = ''
     $script:QtVersion = '5'
@@ -59,6 +60,7 @@ function Build {
 
     (Get-Content -Path ${ProjectRoot}/CMakeLists.txt -Raw) `
         -replace "project\((.*) VERSION (.*)\)", "project(${ProductName} VERSION ${ProductVersion})" `
+        -replace "set\(WINDOWS_APP_ID (.*)\)", "set(WINDOWS_APP_ID ${AppId})" `
         | Out-File -Path ${ProjectRoot}/CMakeLists.txt -NoNewline
 
     Setup-Obs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ set(PLUGIN_AUTHOR "Your Name Here")
 # the installer and when submitting the installer for notarization)
 set(MACOS_BUNDLEID "com.example.${CMAKE_PROJECT_NAME}")
 
+# Set new UUIDs when you start to create a new plugin.
+set(MACOS_PACKAGE_UUID "0B7A74BC-65CF-4FF1-AC34-5C743E8A48F5")
+set(MACOS_INSTALLER_UUID "52B6084A-F58D-45C3-BE37-76AD45F16072")
+set(WINDOWS_APP_ID "CD703FE5-1F2C-4837-BD3D-DD840D83C3E3")
+
 # Replace `me@contoso.com` with the maintainer email address you want to put in Linux packages
 set(LINUX_MAINTAINER_EMAIL "me@mymailhost.com")
 

--- a/buildspec.json
+++ b/buildspec.json
@@ -84,5 +84,8 @@
     "name": "obs-plugintemplate",
     "version": "1.0.0",
     "author": "Your Name Here",
-    "email": "me@mymailhost.com"
+    "email": "me@mymailhost.com",
+    "macosPackageUuid": "0B7A74BC-65CF-4FF1-AC34-5C743E8A48F5",
+    "macosInstallerUuid": "52B6084A-F58D-45C3-BE37-76AD45F16072",
+    "windowsAppId": "CD703FE5-1F2C-4837-BD3D-DD840D83C3E3"
 }

--- a/cmake/bundle/macos/installer-macos.pkgproj.in
+++ b/cmake/bundle/macos/installer-macos.pkgproj.in
@@ -538,7 +538,7 @@
 			<key>TYPE</key>
 			<integer>0</integer>
 			<key>UUID</key>
-			<string>0B7A74BC-65CF-4FF1-AC34-5C743E8A48F5</string>
+			<string>@MACOS_PACKAGE_UUID@</string>
 		</dict>
 	</array>
 	<key>PROJECT</key>
@@ -584,13 +584,13 @@
 									<integer>1</integer>
 								</dict>
 								<key>PACKAGE_UUID</key>
-								<string>0B7A74BC-65CF-4FF1-AC34-5C743E8A48F5</string>
+								<string>@MACOS_PACKAGE_UUID@</string>
 								<key>TITLE</key>
 								<array/>
 								<key>TYPE</key>
 								<integer>0</integer>
 								<key>UUID</key>
-								<string>52B6084A-F58D-45C3-BE37-76AD45F16072</string>
+								<string>@MACOS_INSTALLER_UUID@</string>
 							</dict>
 						</array>
 						<key>REMOVED</key>

--- a/cmake/bundle/windows/installer-Windows.iss.in
+++ b/cmake/bundle/windows/installer-Windows.iss.in
@@ -4,10 +4,7 @@
 #define MyAppURL "http://www.mywebsite.com"
 
 [Setup]
-; NOTE: The value of AppId uniquely identifies this application.
-; Do not use the same AppId value in installers for other applications.
-; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{CD703FE5-1F2C-4837-BD3D-DD840D83C3E3}
+AppId={{@WINDOWS_APP_ID@}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Move the UUIDs to the top of the CMakeLists.txt to clarify plugin developers to change for them.

Also put the UUIDs into `buildspec.json` so that CMakeLists.txt can be overwritten by script and revised build-scripts to overwrite CMakeLists.txt.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The UUIDs for macOS installers and Windows installer should be differentiated for each plugin.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I introduced this change into my plugins (also modified a lot) and released packages. For example,
- https://github.com/norihiro/obs-color-monitor/commit/1d93deabf9af98c0fef5e93f471b895143df0849

The scripts to overwrite CMakeLists.txt is tested on this build. Settings in CMakeLists.txt was filled with invalid text. Then, run the script and checked the settings are overwritten after the script has run.
- https://github.com/norihiro/obs-plugintemplate/actions/runs/3099297250

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
