### PR TITLE
Also use branches named main in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - '**.md'
     branches:
       - master
+      - main
     tags:
       - '*'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - '**.md'
     branches:
       - master
+      - main
 
 env:
   PLUGIN_NAME: 'obs-plugintemplate'


### PR DESCRIPTION
### Description
Since GitHub defaults to 'main' now, also include it in the workflow
when building, so developers don't have to change branch names
if they choose to use it.

### Motivation and Context
Make things easier

### How Has This Been Tested?
Ran workflow

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
