### PR TITLE
Remove Windows 32-bit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch: [x86, x64]
+        arch: [x64]
     if: always()
     needs: [clang_check]
     outputs:


### PR DESCRIPTION
### Description
Removes Windows 32-bit from the GItHub workflow.

### Motivation and Context
Since OBS 28 doesn't support 32-bit, it is pointless to build 32-bit by default. If developers need 32-bit for whatever reason, they can just add this line back in, as the backend scripts still support it.

### How Has This Been Tested?
Ran workflow.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
