### PR TITLE
Auto generate plugin name in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,6 @@ on:
       - master
       - main
 
-env:
-  PLUGIN_NAME: 'obs-plugintemplate'
-
 jobs:
   clang_check:
     name: 01 - Code Format Check
@@ -109,6 +106,8 @@ jobs:
           print "ccacheDate=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
           print "commitHash=${"$(git rev-parse HEAD)"[0,9]}" >> $GITHUB_OUTPUT
 
+          print "pluginName=$(jq -r '.name' buildspec.json)" >> $GITHUB_OUTPUT
+
       - name: Restore Compilation Cache
         id: ccache-cache
         uses: actions/cache@v3
@@ -168,8 +167,8 @@ jobs:
         if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.PLUGIN_NAME }}-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
-          path: ${{ github.workspace }}/plugin/release/${{ env.PLUGIN_NAME }}-*-macos-${{ matrix.arch }}.pkg
+          name: ${{ steps.setup.outputs.pluginName }}-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
+          path: ${{ github.workspace }}/plugin/release/${{ steps.setup.outputs.pluginName }}-*-macos-${{ matrix.arch }}.pkg
 
   linux_build:
     name: 02 - Linux
@@ -207,6 +206,7 @@ jobs:
           ## SETUP ENVIRONMENT SCRIPT
           echo "ccacheDate=$(date +"%Y-%m-%d")" >> $GITHUB_OUTPUT
           echo "commitHash=$(git rev-parse HEAD | cut -c1-9)" >> $GITHUB_OUTPUT
+          echo "pluginName=$(jq -r '.name' buildspec.json)" >> $GITHUB_OUTPUT
 
       - name: Restore Compilation Cache
         id: ccache-cache
@@ -246,8 +246,8 @@ jobs:
         if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.PLUGIN_NAME }}-linux-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
-          path: ${{ github.workspace }}/plugin/release/${{ env.PLUGIN_NAME }}-*-linux-${{ matrix.arch }}.*
+          name: ${{ steps.setup.outputs.pluginName }}-linux-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
+          path: ${{ github.workspace }}/plugin/release/${{ steps.setup.outputs.pluginName }}-*-linux-${{ matrix.arch }}.*
 
   windows_build:
     name: 02 - Windows
@@ -285,6 +285,9 @@ jobs:
           ## SETUP ENVIRONMENT SCRIPT
           $CommitHash = (git rev-parse HEAD)[0..8] -join ''
           "commitHash=${CommitHash}" >> $env:GITHUB_OUTPUT
+          $BuildSpec = Get-Content -Path buildspec.json -Raw | ConvertFrom-Json
+          $PluginName = $BuildSpec.name
+          "pluginName=${PluginName}" >> $env:GITHUB_OUTPUT
 
       - name: Check for GitHub Labels
         id: seekingTesters
@@ -326,8 +329,8 @@ jobs:
         if: ${{ success() && (github.event_name != 'pull_request' || steps.seekingTesters.outputs.found == 'true') }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.PLUGIN_NAME }}-windows-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
-          path: ${{ github.workspace }}/plugin/release/${{ env.PLUGIN_NAME }}-*.zip
+          name: ${{ steps.setup.outputs.pluginName }}-windows-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}
+          path: ${{ github.workspace }}/plugin/release/${{ steps.setup.outputs.pluginName }}-*.zip
 
       - name: Package Plugin Installer
         if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' }}
@@ -342,8 +345,8 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.PLUGIN_NAME }}-windows-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}-installer
-          path: ${{ github.workspace }}/plugin/release/${{ env.PLUGIN_NAME }}-*.exe
+          name: ${{ steps.setup.outputs.pluginName }}-windows-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}-installer
+          path: ${{ github.workspace }}/plugin/release/${{ steps.setup.outputs.pluginName }}-*.exe
 
   make-release:
     name: 03 - Create and upload release
@@ -354,11 +357,19 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: plugin
+          submodules: recursive
+
       - name: Get Metadata
+        working-directory: ${{ github.workspace }}/plugin
         id: metadata
         run: |
           ## METADATA SCRIPT
           echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          echo "pluginName=$(jq -r '.name' buildspec.json)" >> $GITHUB_OUTPUT
 
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -379,7 +390,7 @@ jobs:
           draft: false
           prerelease: ${{ contains(steps.metadata.outputs.version, 'rc') || contains(steps.metadata.outputs.version, 'beta') }}
           tag_name: ${{ steps.metadata.outputs.version }}
-          name: "${{ env.PLUGIN_NAME }} ${{ steps.metadata.outputs.version }}"
+          name: "${{ steps.metadata.outputs.pluginName }} ${{ steps.metadata.outputs.version }}"
           body_path: ${{ github.workspace }}/CHECKSUMS.txt
           files: |
             ${{ github.workspace }}/**/*.zip


### PR DESCRIPTION
### Description
This generates the plugin name based on the name in the buildspec file.

### Motivation and Context
One less file for developers to change.

### How Has This Been Tested?
Ran workflow.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
