### PR TITLE
Change directory for obs-studio

### DIFF
--- a/.github/scripts/utils.pwsh/Setup-Obs.ps1
+++ b/.github/scripts/utils.pwsh/Setup-Obs.ps1
@@ -33,7 +33,7 @@ function Setup-Obs {
     }
 
     Push-Location -Stack BuildTemp
-    Ensure-Location -Path "$(Resolve-Path -Path "${ProjectRoot}/../")/obs-studio"
+    Ensure-Location -Path "$(Resolve-Path -Path "${ProjectRoot}/../")/obs-studio-plugin"
 
     if ( ! ( ( $script:SkipAll ) -or ( $script:SkipUnpack ) ) ) {
         Invoke-GitCheckout -Uri $ObsRepository -Commit $ObsHash -Path . -Branch $ObsBranch

--- a/.github/scripts/utils.zsh/setup_obs
+++ b/.github/scripts/utils.zsh/setup_obs
@@ -43,7 +43,7 @@ if [[ -z ${obs_version} ]] {
 }
 
 pushd
-mkcd ${project_root:h}/obs-studio
+mkcd ${project_root:h}/obs-studio-plugin
 
 if (( ! (${skips[(Ie)all]} + ${skips[(Ie)unpack]}) )) {
   if [[ -d .git ]] {


### PR DESCRIPTION
### Description
If you already have a obs-studio git directory, the
build script will clobber it. This changes the git
directory from obs-studio to obs-studio-plugin.

### Motivation and Context
Frustrated when the build script messes up my obs-studio git directory.
 
### How Has This Been Tested?
Tested with the Linux build script, and it didn't break anything, so it probably works on macOS as well. The Windows one has not been tested yet.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
