### PR TITLE
Use latest OBS with buildspec

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,10 +1,10 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "28.0.0-beta1",
+            "version": "28.0.1",
             "repository": "https://github.com/obsproject/obs-studio.git",
             "branch": "master",
-            "hash": "43a49dca47344a5170159ef99b86b97f90d4e4ad"
+            "hash": "e8dc70d0eef4503378d6ac300e680215eb5c9379"
         },
         "prebuilt": {
             "version": "2022-08-02",


### PR DESCRIPTION
### Description
Updates buildspec file to use latest OBS.

### Motivation and Context
Don't use outdated OBS.

### How Has This Been Tested?
Tested with building plugin.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
