### PR TITLE
Update deb depends to v28 & qt6

### DIFF
--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -104,6 +104,8 @@ macro(find_qt)
     message(FATAL_ERROR "Neither Qt6 nor Qt5 found.")
   endwhile()
 
+  set(QT_VERSION "${_QT_VERSION}")
+
   # Enable versionless targets for the remaining Qt components
   set(QT_NO_CREATE_VERSIONLESS_TARGETS OFF)
 
@@ -504,9 +506,16 @@ else()
       set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-linux-x86_64")
 
       set(CPACK_GENERATOR "DEB")
-      set(CPACK_DEBIAN_PACKAGE_DEPENDS
-          "obs-studio (>= 27.0.0), libqt5core5a (>= 5.9.0~beta), libqt5gui5 (>= 5.3.0), libqt5widgets5 (>= 5.7.0)"
-      )
+
+      if(${QT_VERSION} STREQUAL "6")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS
+            "obs-studio (>= 28.0.0), libqt6core6 (>= 6.2.0), libqt6gui6 (>= 6.1.2), libqt6widgets6 (>= 6.1.2)"
+        )
+      else()
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS
+            "obs-studio (>= 27.0.0), libqt5core5a (>= 5.9.0~beta), libqt5gui5 (>= 5.3.0), libqt5widgets5 (>= 5.7.0)"
+        )
+      endif()
 
       set(CPACK_OUTPUT_FILE_PREFIX ${CMAKE_SOURCE_DIR}/release)
 


### PR DESCRIPTION
### Description
Updates deb files to use OBS 28 and qt6.

### Motivation and Context
Fixes issues when installing deb files.

### How Has This Been Tested?
Ran on workflow.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
