### PR TITLE
Add linux-aarch64 support to build scripts

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -57,6 +57,7 @@ build() {
     macos-arm64
     macos-universal
     linux-x86_64
+    linux-aarch64
   )
   local -r -a _valid_configs=(Debug RelWithDebInfo Release MinSizeRel)
   if [[ ${host_os} == 'macos' ]] {

--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -48,6 +48,7 @@ package() {
     macos-arm64
     macos-universal
     linux-x86_64
+    linux-aarch64
   )
   local -r -a _valid_configs=(Debug RelWithDebInfo Release MinSizeRel)
   local -r _usage="

--- a/buildspec.json
+++ b/buildspec.json
@@ -76,6 +76,9 @@
         },
         "linux-x86_64": {
             "qtVersion": 6
+        },
+        "linux-aarch64": {
+            "qtVersion": 6
         }
     },
     "name": "obs-plugintemplate",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds support for building linux-aarch64 (Arm) to the CI scripts. The change
matches the configuration used for linux-x86_64 builds.

### Motivation and Context
It is useful to use the .github/scripts/build-linux.sh script for building on a local machine, and not just for GitHub actions. By adding AArch64 in this way I'm able
to test the Linux build on my M1 MacBook with a Linux VM.

### How Has This Been Tested?
Tested on a local M1 MacBook with a Parallels virtual machine running a fresh install of Ubuntu. Also pushed out to GitHub so that Actions can test the other build architectures.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
