### PR TITLE
Add author/email parsing to Windows build script

### DIFF
--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -45,6 +45,11 @@ function Build {
     $BuildSpec = Get-Content -Path ${BuildSpecFile} -Raw | ConvertFrom-Json
     $ProductName = $BuildSpec.name
     $ProductVersion = $BuildSpec.version
+    $ProductAuthor = $BuildSpec.author
+    $ProductEmail = $BuildSpec.email
+
+    $ProductAuthor = '"{0}"' -f $ProductAuthor
+    $ProductEmail = '"{0}"' -f $ProductEmail
 
     $script:DepsVersion = ''
     $script:QtVersion = '5'
@@ -59,6 +64,8 @@ function Build {
 
     (Get-Content -Path ${ProjectRoot}/CMakeLists.txt -Raw) `
         -replace "project\((.*) VERSION (.*)\)", "project(${ProductName} VERSION ${ProductVersion})" `
+        -replace "set\(PLUGIN_AUTHOR(.*)\)", "set(PLUGIN_AUTHOR ${ProductAuthor})" `
+        -replace "set\(LINUX_MAINTAINER_EMAIL(.*)\)", "set(LINUX_MAINTAINER_EMAIL ${ProductEmail})" `
         | Out-File -Path ${ProjectRoot}/CMakeLists.txt -NoNewline
 
     Setup-Obs


### PR DESCRIPTION
### Description
The previous commit for this only added it to the Linux/macOS build script.

### Motivation and Context
Forgot to add it to #48 

### How Has This Been Tested?
Ran Windows build script

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
