### PR TITLE
ci: output diff on code format failures

### DIFF
--- a/.github/scripts/check-changes.sh
+++ b/.github/scripts/check-changes.sh
@@ -3,9 +3,10 @@ dirty=$(git ls-files --modified)
 
 set +x
 if [[ $dirty ]]; then
-	echo "================================="
+    echo "================================="
     echo "Files were not formatted properly"
     echo "$dirty"
     echo "================================="
+    git diff
     exit 1
 fi

--- a/.github/scripts/check-cmake.sh
+++ b/.github/scripts/check-cmake.sh
@@ -9,12 +9,6 @@ else
     VERBOSITY=""
 fi
 
-if [ "${CI}" ]; then
-    MODE="--check"
-else
-    MODE="-i"
-fi
-
 # Runs the formatter in parallel on the code base.
 # Return codes:
 #  - 1 there are files to be formatted
@@ -50,4 +44,4 @@ find . -type d \( \
 \) -prune -false -type f -o \
     -name 'CMakeLists.txt' -or \
     -name '*.cmake' \
- | xargs -L10 -P ${NPROC} cmake-format ${MODE} ${VERBOSITY}
+ | xargs -L10 -P ${NPROC} cmake-format -i ${VERBOSITY}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,16 @@ jobs:
         run: sudo apt-get install -y clang-format-13
 
       - name: Run clang-format
-        run: ./.github/scripts/check-format.sh && ./.github/scripts/check-changes.sh
+        run: ./.github/scripts/check-format.sh
 
       - name: Install cmake-format
         run: sudo pip install cmakelang
 
       - name: Run cmake-format
         run: ./.github/scripts/check-cmake.sh
+
+      - name: Check for formatting issues
+        run: ./.github/scripts/check-changes.sh
 
   macos_build:
     name: 02 - macOS


### PR DESCRIPTION
### Description
It is useful to know why the format checks failed. When it happens, use git diff to display the change that is required.

### Motivation and Context
This patch modifies check-cmake.sh to behave the same as check-format.sh. It now unconditionally reformats the file to meet convention which check-changes.sh can detect. Then check-changes.sh can display all the formatting changes in the build log, making it easier to fix the issues quickly.

### How Has This Been Tested?
Tested locally and via GitHub actions CI

Example of output when formatting changes are needed can be seen here:
https://github.com/glikely/obs-plugintemplate/actions/runs/4366259875/jobs/7636020253#step:7:1

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
