### PR TITLE
Remove generated header file from the /src tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,13 +41,13 @@ set_target_properties(
              AUTORCC ON)
 #]]
 
-configure_file(src/plugin-macros.h.in ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.h)
-
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-macros.generated.h)
-
 # /!\ TAKE NOTE: No need to edit things past this point /!\
 
 # --- Platform-independent build settings ---
+
+# These defines are exported out to the compiler
+add_compile_definitions(PLUGIN_NAME="${CMAKE_PROJECT_NAME}"
+                        PLUGIN_VERSION="${CMAKE_PROJECT_VERSION}")
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
 

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -18,7 +18,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <obs-module.h>
 
-#include "plugin-macros.generated.h"
+#include "plugin.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -19,9 +19,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #ifndef PLUGINNAME_H
 #define PLUGINNAME_H
 
-#define PLUGIN_NAME "@CMAKE_PROJECT_NAME@"
-#define PLUGIN_VERSION "@CMAKE_PROJECT_VERSION@"
-
-#define blog(level, msg, ...) blog(level, "[" PLUGIN_NAME "] " msg, ##__VA_ARGS__)
+#include <obs-module.h>
+#define blog(level, msg, ...) \
+	blog(level, "[" PLUGIN_NAME "] " msg, ##__VA_ARGS__)
 
 #endif // PLUGINNAME_H


### PR DESCRIPTION
### Description
A generated header that is created in the source tree causes problems for multiple build directories using the same tree. The plugin-macros header has this problem. It could be solved by moving the generated file into the build directory, but CMake provides a better option. Instead of using a generated .h file, use the add_compile_definitions() macro to add the needed macros to the compiler configuration. This allows the generation of plugin-macros.generated.h to be dropped entirely.

### How Has This Been Tested?
Tested locally on MacOS and Ubuntu, and in GitHub actions CI

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
