### PR TITLE
Allow build scripts to skip more of the dependency setups

### DIFF
--- a/.github/scripts/utils.zsh/check_linux
+++ b/.github/scripts/utils.zsh/check_linux
@@ -1,36 +1,38 @@
 autoload -Uz log_info log_status log_error log_debug log_warning
 
-log_debug 'Checking for apt-get...'
-if (( ! ${+commands[apt-get]} )) {
-  log_error 'No apt-get command found. Please install apt'
-  return 2
-} else {
-  log_debug "Apt-get located at ${commands[apt-get]}"
-}
-
-local -a dependencies=("${(f)$(<${SCRIPT_HOME}/.Aptfile)}")
-local -a install_list
-local binary
-
-for dependency (${dependencies}) {
-  local -a tokens=(${(s: :)dependency//(,|:|\')/})
-
-  if [[ ! ${tokens[1]} == 'package' ]] continue
-
-  if [[ ${#tokens} -gt 2 && ${tokens[3]} == 'bin' ]] {
-    binary=${tokens[4]}
+if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
+  log_debug 'Checking for apt-get...'
+  if (( ! ${+commands[apt-get]} )) {
+    log_error 'No apt-get command found. Please install apt'
+    return 2
   } else {
-    binary=${tokens[2]}
+    log_debug "Apt-get located at ${commands[apt-get]}"
   }
 
-  if (( ! ${+commands[${binary}]} )) install_list+=(${tokens[2]})
-}
+  local -a dependencies=("${(f)$(<${SCRIPT_HOME}/.Aptfile)}")
+  local -a install_list
+  local binary
 
-local -a _quiet=('' '--quiet')
+  for dependency (${dependencies}) {
+    local -a tokens=(${(s: :)dependency//(,|:|\')/})
 
-log_debug "List of dependencies to install: ${install_list}"
-if (( ${#install_list} )) {
-  if (( ! ${+CI} )) log_warning 'Dependency installation via apt may require elevated privileges'
+    if [[ ! ${tokens[1]} == 'package' ]] continue
 
-  sudo apt-get -y install ${install_list} ${_quiet[(( (_loglevel == 0) + 1 ))]}
+    if [[ ${#tokens} -gt 2 && ${tokens[3]} == 'bin' ]] {
+      binary=${tokens[4]}
+    } else {
+      binary=${tokens[2]}
+    }
+
+    if (( ! ${+commands[${binary}]} )) install_list+=(${tokens[2]})
+  }
+
+  local -a _quiet=('' '--quiet')
+
+  log_debug "List of dependencies to install: ${install_list}"
+  if (( ${#install_list} )) {
+    if (( ! ${+CI} )) log_warning 'Dependency installation via apt may require elevated privileges'
+
+    sudo apt-get -y install ${install_list} ${_quiet[(( (_loglevel == 0) + 1 ))]}
+  }
 }

--- a/.github/scripts/utils.zsh/check_macos
+++ b/.github/scripts/utils.zsh/check_macos
@@ -10,11 +10,13 @@ else
   log_status "macOS ${macos_version} is recent"
 fi
 
-log_info 'Checking for Homebrew...'
-if (( ! ${+commands[brew]} )) {
-  log_error 'No Homebrew command found. Please install Homebrew (https://brew.sh)'
-  return 2
-}
+if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
+  log_info 'Checking for Homebrew...'
+  if (( ! ${+commands[brew]} )) {
+    log_error 'No Homebrew command found. Please install Homebrew (https://brew.sh)'
+    return 2
+  }
 
-brew bundle --file "${SCRIPT_HOME}/.Brewfile"
-rehash
+  brew bundle --file "${SCRIPT_HOME}/.Brewfile"
+  rehash
+}

--- a/.github/scripts/utils.zsh/setup_obs
+++ b/.github/scripts/utils.zsh/setup_obs
@@ -45,7 +45,7 @@ if [[ -z ${obs_version} ]] {
 pushd
 mkcd ${project_root:h}/obs-studio
 
-if (( ! (${skips[(Ie)all]} + ${skips[(Ie)unpack]}) )) {
+if (( ! (${skips[(Ie)all]} + ${skips[(Ie)unpack]} + ${skips[(Ie)deps]}) )) {
   if [[ -d .git ]] {
     git config advice.detachedHead false
     git config remote.pluginbuild.url "${obs_repo:-https://github.com/obsproject/obs-studio.git}"
@@ -67,7 +67,7 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)unpack]}) )) {
   git submodule update --init --recursive
 }
 
-if (( ! (${skips[(Ie)all]} + ${skips[(Ie)build]}) )) {
+if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
   log_info 'Configuring obs-studio...'
 
   local -a cmake_args=(


### PR DESCRIPTION
### Description
This branch modifies the build scripts to allow package management tasks (Apt or Homebrew) and building obs-studio to be skipped entirely with --skip-deps.

### Motivation and Context
The CI build script is also really useful during development to do all the things needed to rebuild the plugin. However, it can be quite slow to run build_{macos,linux}.zsh because even if --skip-deps is specified, it still does a bunch of package management tasks and builds the obs-studio source tree. A plugin developer is most likely focusing on their plugin's source code rather than changing obs-studio code itself, so it makes sense to have an option to skip.

### How Has This Been Tested?
Tested on MacOS and using GitHub actions CI to confirm build still works.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
