### PR TITLE
Use `example.com` as placeholder, fixes #70

### DIFF
--- a/cmake/bundle/windows/installer-Windows.iss.in
+++ b/cmake/bundle/windows/installer-Windows.iss.in
@@ -1,7 +1,7 @@
 #define MyAppName "@CMAKE_PROJECT_NAME@"
 #define MyAppVersion "@CMAKE_PROJECT_VERSION@"
 #define MyAppPublisher "@PLUGIN_AUTHOR@"
-#define MyAppURL "http://www.mywebsite.com"
+#define MyAppURL "http://www.example.com"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.


### PR DESCRIPTION
`mywebsite.com` redirects to a phishing/tech support scam, see #70 for details.  Instead use `example.com`, which is reserved by IANA specifically for use as an example/placeholder.

Fixes #70.