### PR TITLE
Install obs-studio from ppa

### DIFF
--- a/.github/scripts/utils.zsh/setup_linux
+++ b/.github/scripts/utils.zsh/setup_linux
@@ -35,10 +35,13 @@ if (( ! (${skips[(Ie)all]} + ${skips[(Ie)deps]}) )) {
     sudo apt-get install ${apt_args} gcc-${${target##*-}//_/-}-linux-gnu g++-${${target##*-}//_/-}-linux-gnu
   }
 
+  sudo add-apt-repository --yes ppa:obsproject/obs-studio
+  sudo apt update
+
   sudo apt-get install ${apt_args} \
     build-essential \
     libgles2-mesa-dev \
-    libobs-dev${suffix}
+    obs-studio
 
   local -a _qt_packages=()
 


### PR DESCRIPTION
### Description
This installs OBS Studio from the OBS ppa. This is a temporary fix to prevent the CI from failing if a developer uses newer code then what the unofficial Ubuntu repo provides (27.2.3 on 22.04). This isn't ideal as it installs the entire program instead of just dev packages. In the future, we would provide a libobs-dev package on our ppa.

### Motivation and Context
CI currently fails if developers use newer OBS apis.

### How Has This Been Tested?
Ran CI with one of my plugins

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
