### PR TITLE
CI: Fix missing codesign team on packaging

### DIFF
--- a/.github/actions/package-plugin/action.yaml
+++ b/.github/actions/package-plugin/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: 'Developer ID for installer package codesigning (macOS only)'
     required: false
     default: ''
+  codesignTeam:
+    description: 'Developer team for codesigning (macOS only)'
+    required: false
+    default: ''
   codesignUser:
     description: 'Apple ID username for notarization (macOS only)'
     required: false
@@ -50,6 +54,7 @@ runs:
       env:
         CODESIGN_IDENT: ${{ inputs.codesignIdent }}
         CODESIGN_IDENT_INSTALLER: ${{ inputs.installerIdent }}
+        CODESIGN_TEAM: ${{ inputs.codesignTeam }}
         CODESIGN_IDENT_USER: ${{ inputs.codesignUser }}
         CODESIGN_IDENT_PASS: ${{ inputs.codesignPass }}
       run: |

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -129,6 +129,7 @@ jobs:
           codesign: ${{ fromJSON(needs.check-event.outputs.codesign) && fromJSON(steps.codesign.outputs.haveCodesignIdent) }}
           codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
           installerIdent: ${{ steps.codesign.outputs.installerIdent }}
+          codesignTeam: ${{ steps.codesign.outputs.codesignTeam }}
           notarize: ${{ fromJSON(needs.check-event.outputs.notarize) && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
           codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
           codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The current workflow fails when it builds the macOS package with nortorization.
https://github.com/umireon/obs-pokemon-sv-screen-builder/actions/runs/5471889748/jobs/9963806267#step:7:375
This PR fix the workflow to provide CODESIGN_TEAM to the packaging action.

### Motivation and Context
Releasing the obs plugin always fails and I cannot release the package so I need to fix this problem.

### How Has This Been Tested?
This change fix the problem on my repository.
https://github.com/umireon/obs-pokemon-sv-screen-builder/actions/runs/5474739649/jobs/9969905028

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
