### PR TITLE
cmake: Use C17 only with CMake 3.21 or above

### DIFF
--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -3,7 +3,7 @@
 include_guard(GLOBAL)
 
 # Set C and C++ language standards to C17 and C++17
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.21)
   set(CMAKE_C_STANDARD 17)
 else()
   set(CMAKE_C_STANDARD 11)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
C17 is not supported until CMake 3.21 and C17 must be used with CMake 3.21 or above.
https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
CMake 3.20 is provided on openSUSE Leap 15.5 and the plugin building with CMake commands fails with the message that CMake does not understand the C standard of C17.
I need this bug to be fixed to build on openSUSE Leap.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
This change is tested in our plugin.
https://github.com/royshil/obs-backgroundremoval/pull/430

The building log of our plugin with this change is available:
https://pmbs.links2linux.org/package/live_build_log/home:umireon/obs-backgroundremoval/15.5/x86_64
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
