### PR TITLE
CI: update macos Packages framework to latest version 1.2.10

### DIFF
--- a/.github/scripts/utils.zsh/check_packages
+++ b/.github/scripts/utils.zsh/check_packages
@@ -54,7 +54,7 @@ Actual   : ${checksum}"
 
   log_status 'Installing Packages.app requires elevated privileges!'
 
-  sudo installer -pkg ${mount_point}/packages/Packages.pkg -target / && rehash
+  sudo installer -pkg "${mount_point}/Install Packages.pkg" -target / && rehash
   hdiutil detach ${mount_point} &> /dev/null && log_status 'Packages.dmg image unmounted.'
   popd
 

--- a/buildspec.json
+++ b/buildspec.json
@@ -36,7 +36,7 @@
             "version": "1.2.10",
             "baseUrl": "http://s.sudre.free.fr/Software/files",
             "label": "Packages.app",
-            "hash": "6afdd25386295974dad8f078b8f1e41cabebd08e72d970bf92f707c7e48b16c9"
+            "hash": "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
         }
     },
     "platformConfig": {


### PR DESCRIPTION
Update the hash and package installation path so that macos packaging works with the latest version 1.2.10 from http://s.sudre.free.fr/Software/Packages/about.html
