### PR TITLE
cmake: Fix optional target installation into wrong plugin directory

### DIFF
--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -43,7 +43,7 @@ function(set_target_properties_plugin target)
       POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_BUILD_DIR}/obs-plugins/64bit"
       COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${target}>"
-              "$<$<CONFIG:Debug,RelWithDebInfo>:$<TARGET_PDB_FILE:${target}>>" "${OBS_BUILD_DIR}/obs-plugin/64bit"
+              "$<$<CONFIG:Debug,RelWithDebInfo>:$<TARGET_PDB_FILE:${target}>>" "${OBS_BUILD_DIR}/obs-plugins/64bit"
       COMMENT "Copy ${target} to obs-studio directory ${OBS_BUILD_DIR}"
       VERBATIM)
   endif()


### PR DESCRIPTION
### Description
Fix output directory for target installation into an active `obs-studio` build tree.

### Motivation and Context
Fixes https://github.com/obsproject/obs-plugintemplate/issues/93.

### How Has This Been Tested?
Tested on Windows 11 with existing `obs-studio` build directory.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
