### PR TITLE
CI: Fix `pull_request` gh "could not determine current branch"

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 jobs:
   check-event:
-    name: Check GitHub Event Data 📡
+    name: Check GitHub Event Data 🔎
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -29,7 +29,7 @@ jobs:
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
               config_data=('codesign:false' 'notarize:false' 'package:false' 'config:RelWithDebInfo')
-              if gh pr view --json labels \
+              if gh pr view ${{ github.event.number }} --json labels \
                 | jq -e -r '.labels[] | select(.name == "Seeking Testers")' > /dev/null; then
                 config_data[0]='codesign:true'
                 config_data[2]='package:true'
@@ -77,9 +77,9 @@ jobs:
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
           print '::group::Clean Homebrew Environment'
-          typeset -a to_remove=()
+          local -a to_remove=()
 
-          if (( #to_remove > 0 )) brew uninstall --ignore-dependencies ${to_remove}
+          if (( #to_remove )) brew uninstall --ignore-dependencies ${to_remove}
           print '::endgroup::'
 
           local product_name
@@ -100,7 +100,7 @@ jobs:
 
       - name: Set Up Codesigning 🔑
         uses: ./.github/actions/setup-macos-codesigning
-        if: ${{ fromJSON(needs.check-event.outputs.codesign) }}
+        if: fromJSON(needs.check-event.outputs.codesign)
         id: codesign
         with:
           codesignIdentity: ${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}


### PR DESCRIPTION
Also updating `.github\workflows\build-project.yaml` with a few of the latest compatible changes in obs-studio's same file.

### Description
Fixing `.github/workflows/build-project.yaml` `GITHUB_EVENT_NAME` `pull_request` `gh` failing and reporting "could not determine current branch".

### Motivation and Context
`.github\workflows\build-project.yaml` has some code that supports packaging the plugin with a `Seeking Testers` label.
https://github.com/obsproject/obs-plugintemplate/blob/57cdde9d8120b7b196a2c4612131b3078f893ad9/.github/workflows/build-project.yaml#L32-L36

This wasn't working because `gh` complained "could not determine current branch":
https://github.com/obsproject/obs-plugintemplate/actions/runs/6657042057/job/18090925431 
![image](https://github.com/obsproject/obs-plugintemplate/assets/1393897/0d123533-8fb6-4de1-b3c8-4a38a9e7ce64)

This code is based on obs-studio's:
https://github.com/obsproject/obs-studio/blob/64be5a7f9a90c6d2159ba60613d0fc421c40621c/.github/workflows/build-project.yaml#L32-L36

@PatTheMav might have noticed this wasn't working in obs-studio and fixed it with the following on 2023/09/05:
https://github.com/obsproject/obs-studio/commit/a2c0d4969aa35067455814d20cc87f9f9486c370#diff-58a222b2569531e3ee88d373cb6b2a3b0e4d1b24ebd09ba9d03e12b6f110bb03R32

I copied that one line32 change and now the "Seeking Testers" feature works.
While I was in that file I also copied a few of the other compatible changes.

### How Has This Been Tested?
https://github.com/obs-ndi/obs-ndi/actions/runs/6748286871 ran with this change and the "Seeking Testers" label and correctly packaged the installers.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
