### PR TITLE
CI: Fix random password generation for macOS codesigning

### DIFF
--- a/.github/actions/setup-macos-codesigning/action.yaml
+++ b/.github/actions/setup-macos-codesigning/action.yaml
@@ -75,7 +75,7 @@ runs:
 
           print -n "${MACOS_SIGNING_CERT}" | base64 --decode --output="${certificate_path}"
 
-          : "${MACOS_KEYCHAIN_PASSWORD:="$(print ${RANDOM} | sha1sum | head -c 32)"}"
+          : "${MACOS_KEYCHAIN_PASSWORD:="$(print ${RANDOM} | shasum | head -c 32)"}"
 
           print '::group::Keychain setup'
           security create-keychain -p "${MACOS_KEYCHAIN_PASSWORD}" ${keychain_path}


### PR DESCRIPTION
`sha1sum` is part of Homebrew's coreutils, but macOS ships with `shasum` by default, which supports many variants and defaults to SHA-1 by default.
This is essentially a cherry-pick of:
https://github.com/obsproject/obs-studio/commit/1e74256b7ea438f01d3146d3411246215a19cbf5

### Description
Build is outputting this error:
```
Run : macOS Codesigning ✍️
/Users/runner/work/_temp/f1d2ceff-9fa3-45ff-9e47-d545a0f36982:12: command not found: sha1sum
```

### Motivation and Context
@PatTheMav noticed this in the OBS build and fixed it there:
https://github.com/obsproject/obs-studio/commit/1e74256b7ea438f01d3146d3411246215a19cbf5
Doing the same here.

### How Has This Been Tested?
Build no longer outputs:
```
Run : macOS Codesigning ✍️
/Users/runner/work/_temp/f1d2ceff-9fa3-45ff-9e47-d545a0f36982:12: command not found: sha1sum
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
