### PR TITLE
Build plugin support library with PIC on Linux and BSD

### DIFF
--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -134,4 +134,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/plugin-support.c.in")
     PRIVATE plugin-support.c
     PUBLIC src/plugin-support.h)
   target_include_directories(plugin-support PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  if(UNIX AND NOT APPLE)
+    # add fPIC on Linux to prevent shared object errors
+    set_property(TARGET plugin-support PROPERTY POSITION_INDEPENDENT_CODE ON)
+  endif()
 endif()

--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -134,7 +134,9 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/plugin-support.c.in")
     PRIVATE plugin-support.c
     PUBLIC src/plugin-support.h)
   target_include_directories(plugin-support PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
-  if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
+  if(OS_LINUX
+     OR OS_FREEBSD
+     OR OS_OPENBSD)
     # add fPIC on Linux to prevent shared object errors
     set_property(TARGET plugin-support PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()

--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -134,7 +134,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/plugin-support.c.in")
     PRIVATE plugin-support.c
     PUBLIC src/plugin-support.h)
   target_include_directories(plugin-support PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
-  if(UNIX AND NOT APPLE)
+  if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
     # add fPIC on Linux to prevent shared object errors
     set_property(TARGET plugin-support PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adding `-fPIC` on Linux when compiling the `libplugin-support.a` static lib, otherwise some Linux OSs build complain e.g.
```
/usr/bin/ld: libplugin-support.a(plugin-support.c.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixing Linux build for OSs such as Fedora.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built on Mac, Windows and Linux (Ubuntu).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Effectively a bugfix?

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
