### PR TITLE
CI: Set Windows packaging to default to zip

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -64,10 +64,20 @@ function Package {
 
     Remove-Item @RemoveArgs
 
+    Log-Group "Archiving ${ProductName}..."
+    $CompressArgs = @{
+        Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*")
+        CompressionLevel = 'Optimal'
+        DestinationPath = "${ProjectRoot}/release/${OutputName}.zip"
+        Verbose = ($Env:CI -ne $null)
+    }
+    Compress-Archive -Force @CompressArgs
+    Log-Group
+
     if ( ( $BuildInstaller ) ) {
         Log-Group "Packaging ${ProductName}..."
-        $IsccFile = "${ProjectRoot}/build_${Target}/installer-Windows.generated.iss"
 
+        $IsccFile = "${ProjectRoot}/build_${Target}/installer-Windows.generated.iss"
         if ( ! ( Test-Path -Path $IsccFile ) ) {
             throw 'InnoSetup install script not found. Run the build script or the CMake build and install procedures first.'
         }
@@ -79,18 +89,9 @@ function Package {
         Invoke-External iscc ${IsccFile} /O"${ProjectRoot}/release" /F"${OutputName}-Installer"
         Remove-Item -Path Package -Recurse
         Pop-Location -Stack BuildTemp
-    } else {
-        Log-Group "Archiving ${ProductName}..."
-        $CompressArgs = @{
-            Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*")
-            CompressionLevel = 'Optimal'
-            DestinationPath = "${ProjectRoot}/release/${OutputName}.zip"
-            Verbose = ($Env:CI -ne $null)
-        }
 
-        Compress-Archive -Force @CompressArgs
+        Log-Group
     }
-    Log-Group
 }
 
 Package


### PR DESCRIPTION
### Description
Change `Package-Windows.ps1` from:
```
if ( ( $BuildInstaller ) ) {
  // package .msi
} else {
  // generate .zip
}
```
to
```
// generate .zip
if ( ( $BuildInstaller ) ) {
  // package .msi
}
```

### Motivation and Context
The current code either packages a .msi **or** generates a .zip.  
Many users prefer the zip (and it has the benefit of mitigating code signing warnings).  
This change always generates the .zip file.  
If `-BuildInstaller` is also specified then is **also** builds a .msi.

### How Has This Been Tested?
`.github/scripts/Build-Windows.ps1 -SkipDeps && .github/scripts/Package-Windows.ps1 -BuildInstaller` outputs both .zip and .msi
`.github/scripts/Build-Windows.ps1 -SkipDeps && .github/scripts/Package-Windows.ps1` outputs .zip

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

Do we need to document any changes in this PR, or a future one?

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
