### PR TITLE
cmake: Force PDB generation on Windows for MSVC builds in all configs

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -9,6 +9,15 @@ if(CMAKE_VERSION VERSION_EQUAL 3.24.0)
   set(THREADS_HAVE_PTHREAD_ARG FALSE)
 endif()
 
+# CMake 3.25 changed the way symbol generation is handled on Windows
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+  if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT ProgramDatabase)
+  else()
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+  endif()
+endif()
+
 message(DEBUG "Current Windows API version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM)
   message(DEBUG "Maximum Windows API version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM}")
@@ -20,15 +29,24 @@ if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS 10.0.20348)
 endif()
 
 add_compile_options(
-  /W3 /utf-8 "$<$<COMPILE_LANG_AND_ID:C,MSVC>:/MP>" "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MP>"
+  /W3
+  /utf-8
+  "$<$<COMPILE_LANG_AND_ID:C,MSVC>:/MP>"
+  "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MP>"
   "$<$<COMPILE_LANG_AND_ID:C,Clang>:${_obs_clang_c_options}>"
-  "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${_obs_clang_cxx_options}>")
+  "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${_obs_clang_cxx_options}>"
+  $<$<NOT:$<CONFIG:Debug>>:/Gy>)
 
 add_compile_definitions(UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS $<$<CONFIG:DEBUG>:DEBUG>
                         $<$<CONFIG:DEBUG>:_DEBUG>)
 
-add_link_options("$<$<NOT:$<CONFIG:Debug>>:/OPT:REF>" "$<$<CONFIG:Debug>:/INCREMENTAL:NO>"
-                 "$<$<CONFIG:RelWithDebInfo>:/INCREMENTAL:NO>" "$<$<CONFIG:RelWithDebInfo>:/OPT:ICF>")
+# cmake-format: off
+add_link_options($<$<NOT:$<CONFIG:Debug>>:/OPT:REF>
+                 $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>
+                 $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
+                 /DEBUG
+                 /Brepro)
+# cmake-format: on
 
 if(CMAKE_COMPILE_WARNING_AS_ERROR)
   add_link_options(/WX)

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -33,7 +33,7 @@ function(set_target_properties_plugin target)
 
   install(
     FILES "$<TARGET_PDB_FILE:${target}>"
-    CONFIGURATIONS RelWithDebInfo Debug
+    CONFIGURATIONS RelWithDebInfo Debug Release
     DESTINATION obs-plugins/64bit
     OPTIONAL)
 
@@ -42,8 +42,9 @@ function(set_target_properties_plugin target)
       TARGET ${target}
       POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_BUILD_DIR}/obs-plugins/64bit"
-      COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${target}>"
-              "$<$<CONFIG:Debug,RelWithDebInfo>:$<TARGET_PDB_FILE:${target}>>" "${OBS_BUILD_DIR}/obs-plugins/64bit"
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${target}>"
+        "$<$<CONFIG:Debug,RelWithDebInfo,Release>:$<TARGET_PDB_FILE:${target}>>" "${OBS_BUILD_DIR}/obs-plugins/64bit"
       COMMENT "Copy ${target} to obs-studio directory ${OBS_BUILD_DIR}"
       VERBATIM)
   endif()


### PR DESCRIPTION
### Description
This is a bugfix written by PatTheMav for obs-studio which applies equally to obs-plugintemplate.
Quote [1]:
CMake 3.25 changed the way PDB generation is handled by only enabling it for Debug and RelWithDebInfo builds, which prohibits generation of fully optimized builds with associated symbols (which is MSVC's default).

If configuring with CMake 3.25 or above, enable this globally for builds using MSVC and fall back to embedded debug information for anything else (which would probably be clang-cl)

### Motivation and Context
CI builds tags as Release. As a result, there's no pdb generated.
It is desirable to ship pdb for better user support.

### How Has This Been Tested?
Tested on a third-party plugin.
The pdb are generated now in Release builds.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
