### PR TITLE
CI: Expose detected plugin name to other workflow jobs

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -1,6 +1,10 @@
 name: Build Project
 on:
   workflow_call:
+    outputs:
+      pluginName:
+        description: 'Project name detected by parsing build spec file'
+        value: ${{ jobs.check-event.outputs.pluginName }}
 jobs:
   check-event:
     name: Check GitHub Event Data 🔎
@@ -14,6 +18,7 @@ jobs:
       notarize: ${{ steps.setup.outputs.notarize }}
       config: ${{ steps.setup.outputs.config }}
       commitHash: ${{ steps.setup.outputs.commitHash }}
+      pluginName: ${{ steps.setup.outputs.pluginName }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -56,6 +61,15 @@ jobs:
             echo "${key}=${value}" >> $GITHUB_OUTPUT
           done
           echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
+
+          plugin_name="$(grep 'name' buildspec.json | sed -E -e 's/^.+"name":[^"]+"(.+)",?$/\1/g')"
+          plugin_display_name="$(grep 'displayName' buildspec.json | sed -E -e 's/^.+"displayName":[^"]+"(.+)",?$/\1/g' || echo "")"
+
+          if [[ "${plugin_display_name}" ]]; then
+            echo "pluginName=${plugin_display_name}" >> $GITHUB_OUTPUT
+          else
+            echo "pluginName=${plugin_name}" >> $GITHUB_OUTPUT
+          fi
 
   macos-build:
     name: Build for macOS 🍏

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -111,7 +111,7 @@ jobs:
           draft: true
           prerelease: ${{ fromJSON(steps.check.outputs.prerelease) }}
           tag_name: ${{ steps.check.outputs.version }}
-          name: OBS Studio ${{ steps.check.outputs.version }}
+          name: ${{ needs.build-project.outputs.pluginName }} ${{ steps.check.outputs.version }}
           body_path: ${{ github.workspace }}/CHECKSUMS.txt
           files: |
             ${{ github.workspace }}/*.exe

--- a/buildspec.json
+++ b/buildspec.json
@@ -37,6 +37,7 @@
         }
     },
     "name": "obs-plugintemplate",
+    "displayName": "OBS Plugin Template",
     "version": "1.0.0",
     "author": "Your Name Here",
     "website": "https://example.com",


### PR DESCRIPTION
### Description
Adds early detection of the configured plugin name in workflows so the name can be re-used in later workflows without the need to do a full repository checkout or installation of 3rd party utilities (e.g. the release creation step).

### Motivation and Context
Reduce necessary fixup steps for plugin developers when finalising their releases.

Fixes https://github.com/obsproject/obs-plugintemplate/issues/105.

### How Has This Been Tested?
Tested with a tagged release on a fork of the repository.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
