### PR TITLE
Update clang-format to 16

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -28,7 +28,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@13/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@16/bin" >> $GITHUB_PATH
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -51,11 +51,11 @@ runs:
         }
 
         if (( ${changes[(I)(*.c|*.h|*.cpp|*.hpp|*.m|*.mm)]} )) {
-          echo ::group::Install clang-format-13
-          brew install --quiet obsproject/tools/clang-format@13
+          echo ::group::Install clang-format-16
+          brew install --quiet obsproject/tools/clang-format@16
           echo ::endgroup::
 
-          echo ::group::Run clang-format-13
+          echo ::group::Run clang-format-16
           ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check
           echo ::endgroup::
         }

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -29,23 +29,23 @@ invoke_formatter() {
 
   case ${1} {
     clang)
-      if (( ${+commands[clang-format-13]} )) {
-        local formatter=clang-format-13
+      if (( ${+commands[clang-format-16]} )) {
+        local formatter=clang-format-16
       } elif (( ${+commands[clang-format]} )) {
         local formatter=clang-format
         local -a formatter_version=($(clang-format --version))
 
-        if ! is-at-least 13.0.1 ${formatter_version[-1]}; then
-          log_error "clang-format is not version 13.0.1 or above (found ${formatter_version[-1]}."
+        if ! is-at-least 16.0.5 ${formatter_version[-1]}; then
+          log_error "clang-format is not version 16.0.5 or above (found ${formatter_version[-1]}."
           exit 2
         fi
 
-        if ! is-at-least ${formatter_version[-1]} 13.0.1; then
-          log_error "clang-format is more recent than version 13.0.1 (found ${formatter_version[-1]})."
+        if ! is-at-least ${formatter_version[-1]} 16.0.5; then
+          log_error "clang-format is more recent than version 16.0.5 (found ${formatter_version[-1]})."
           exit 2
         fi
       } else {
-        log_error "No viable clang-format version found (required 13.0.1)"
+        log_error "No viable clang-format version found (required 16.0.5)"
         exit 2
       }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Upgrade clang-format used in actions to 16

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With changes introduced in https://github.com/obsproject/obs-plugintemplate/pull/82 clang-format 16 is now required. Using the current version of 13 will result in a `.clang-format:115:3: error: unknown enumerated scalar` error

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have made small edits to code files which should trigger the github action which I will then revert.
I have also implemented this change into my own plugin after merging latest. https://github.com/EZ64cool/obs-hadowplay/actions/workflows/pr-pull.yaml?query=branch%3Amerging_template

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
