### PR TITLE
cmake: Move common variables to an inherited preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,9 +7,18 @@
   },
   "configurePresets": [
     {
+      "name": "template",
+      "hidden": true,
+      "cacheVariables": {
+        "ENABLE_FRONTEND_API": false,
+        "ENABLE_QT": false
+      }
+    },
+    {
       "name": "macos",
       "displayName": "macOS Universal",
       "description": "Build for macOS 11.0+ (Universal binary)",
+      "inherits": ["template"],
       "binaryDir": "${sourceDir}/build_macos",
       "condition": {
         "type": "equals",
@@ -22,9 +31,7 @@
         "QT_VERSION": "6",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
         "CODESIGN_IDENTITY": "$penv{CODESIGN_IDENT}",
-        "CODESIGN_TEAM": "$penv{CODESIGN_TEAM}",
-        "ENABLE_FRONTEND_API": false,
-        "ENABLE_QT": false
+        "CODESIGN_TEAM": "$penv{CODESIGN_TEAM}"
       }
     },
     {
@@ -41,6 +48,7 @@
       "name": "windows-x64",
       "displayName": "Windows x64",
       "description": "Build for Windows x64",
+      "inherits": ["template"],
       "binaryDir": "${sourceDir}/build_x64",
       "condition": {
         "type": "equals",
@@ -52,9 +60,7 @@
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
         "QT_VERSION": "6",
-        "CMAKE_SYSTEM_VERSION": "10.0.18363.657",
-        "ENABLE_FRONTEND_API": false,
-        "ENABLE_QT": false
+        "CMAKE_SYSTEM_VERSION": "10.0.18363.657"
       }
     },
     {
@@ -70,6 +76,7 @@
       "name": "linux-x86_64",
       "displayName": "Linux x86_64",
       "description": "Build for Linux x86_64",
+      "inherits": ["template"],
       "binaryDir": "${sourceDir}/build_x86_64",
       "condition": {
         "type": "equals",
@@ -80,9 +87,7 @@
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
         "QT_VERSION": "6",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "ENABLE_FRONTEND_API": false,
-        "ENABLE_QT": false
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
@@ -99,6 +104,7 @@
       "name": "linux-aarch64",
       "displayName": "Linux aarch64",
       "description": "Build for Linux aarch64",
+      "inherits": ["template"],
       "binaryDir": "${sourceDir}/build_aarch64",
       "condition": {
         "type": "equals",
@@ -109,9 +115,7 @@
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
         "QT_VERSION": "6",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "ENABLE_FRONTEND_API": false,
-        "ENABLE_QT": false
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Move ENABLE_FRONTEND_API and ENABLE_QT from individual presets to a common preset that is hidden but inherited by the individual presets.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Generally, these will have the same values on all platforms. Make it easier for plugin devs to enable or disable Frontend API and Qt for all presets/platforms.

Devs can still override this per preset if needed by simply setting a different value in an individual preset.

Fixes #103

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Haven't tested locally. CI should be able to test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
