### PR TITLE
cmake: Remove Qt version selection and Qt 5 support

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -6,15 +6,6 @@
     "autosort": true
   },
   "additional_commands": {
-    "find_qt": {
-      "flags": [],
-      "kwargs": {
-        "COMPONENTS": "+",
-        "COMPONENTS_WIN": "+",
-        "COMPONENTS_MACOS": "+",
-        "COMPONENTS_LINUX": "+"
-      }
-    },
     "set_target_properties_obs": {
       "pargs": 1,
       "flags": [],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ if(ENABLE_FRONTEND_API)
 endif()
 
 if(ENABLE_QT)
-  find_qt(COMPONENTS Widgets Core)
-  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)
+  find_package(Qt6 COMPONENTS Widgets Core)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt6::Core Qt6::Widgets)
   target_compile_options(
     ${CMAKE_PROJECT_NAME} PRIVATE $<$<C_COMPILER_ID:Clang,AppleClang>:-Wno-quoted-include-in-framework-header
                                   -Wno-comma>)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,7 +28,6 @@
       "generator": "Xcode",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "QT_VERSION": "6",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
         "CODESIGN_IDENTITY": "$penv{CODESIGN_IDENT}",
         "CODESIGN_TEAM": "$penv{CODESIGN_TEAM}"
@@ -59,7 +58,6 @@
       "architecture": "x64",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "QT_VERSION": "6",
         "CMAKE_SYSTEM_VERSION": "10.0.18363.657"
       }
     },
@@ -86,7 +84,6 @@
       "generator": "Ninja",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "QT_VERSION": "6",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
@@ -114,7 +111,6 @@
       "generator": "Ninja",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "QT_VERSION": "6",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },

--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -6,16 +6,6 @@
 
 include_guard(GLOBAL)
 
-# * Use QT_VERSION value as a hint for desired Qt version
-# * If "AUTO" was specified, prefer Qt6 over Qt5
-# * Creates versionless targets of desired component if none had been created by Qt itself (Qt versions < 5.15)
-if(NOT QT_VERSION)
-  set(QT_VERSION
-      AUTO
-      CACHE STRING "OBS Qt version [AUTO, 5, 6]" FORCE)
-  set_property(CACHE QT_VERSION PROPERTY STRINGS AUTO 5 6)
-endif()
-
 # find_qt: Macro to find best possible Qt version for use with the project:
 macro(find_qt)
   set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC COMPONENTS_LINUX)
@@ -25,38 +15,11 @@ macro(find_qt)
   # find_package runs
   set(QT_NO_CREATE_VERSIONLESS_TARGETS TRUE)
 
-  message(DEBUG "Start Qt version discovery...")
-  # Loop until _QT_VERSION is set or FATAL_ERROR aborts script execution early
-  while(NOT _QT_VERSION)
-    message(DEBUG "QT_VERSION set to ${QT_VERSION}")
-    if(QT_VERSION STREQUAL AUTO AND NOT qt_test_version)
-      set(qt_test_version 6)
-    elseif(NOT QT_VERSION STREQUAL AUTO)
-      set(qt_test_version ${QT_VERSION})
-    endif()
-    message(DEBUG "Attempting to find Qt${qt_test_version}")
-
-    find_package(
-      Qt${qt_test_version}
-      COMPONENTS Core
-      QUIET)
-
-    if(TARGET Qt${qt_test_version}::Core)
-      set(_QT_VERSION
-          ${qt_test_version}
-          CACHE INTERNAL "")
-      message(STATUS "Qt version found: ${_QT_VERSION}")
-      unset(qt_test_version)
-      break()
-    elseif(QT_VERSION STREQUAL AUTO)
-      if(qt_test_version EQUAL 6)
-        message(WARNING "Qt6 was not found, falling back to Qt5")
-        set(qt_test_version 5)
-        continue()
-      endif()
-    endif()
-    message(FATAL_ERROR "Neither Qt6 nor Qt5 found.")
-  endwhile()
+  message(DEBUG "Attempting to find Qt 6")
+  find_package(
+    Qt6
+    COMPONENTS Core
+    REQUIRED)
 
   # Enable versionless targets for the remaining Qt components
   set(QT_NO_CREATE_VERSIONLESS_TARGETS FALSE)
@@ -71,7 +34,7 @@ macro(find_qt)
   endif()
   message(DEBUG "Trying to find Qt components ${qt_components}...")
 
-  find_package(Qt${_QT_VERSION} REQUIRED ${qt_components})
+  find_package(Qt6 REQUIRED ${qt_components})
 
   list(APPEND qt_components Core)
 
@@ -82,9 +45,9 @@ macro(find_qt)
   # Check for versionless targets of each requested component and create if necessary
   foreach(component IN LISTS qt_components)
     message(DEBUG "Checking for target Qt::${component}")
-    if(NOT TARGET Qt::${component} AND TARGET Qt${_QT_VERSION}::${component})
+    if(NOT TARGET Qt::${component} AND TARGET Qt6::${component})
       add_library(Qt::${component} INTERFACE IMPORTED)
-      set_target_properties(Qt::${component} PROPERTIES INTERFACE_LINK_LIBRARIES Qt${_QT_VERSION}::${component})
+      set_target_properties(Qt::${component} PROPERTIES INTERFACE_LINK_LIBRARIES Qt6::${component})
     endif()
     set_property(TARGET Qt::${component} PROPERTY INTERFACE_COMPILE_FEATURES "")
   endforeach()

--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -6,54 +6,6 @@
 
 include_guard(GLOBAL)
 
-# find_qt: Macro to find best possible Qt version for use with the project:
-macro(find_qt)
-  set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC COMPONENTS_LINUX)
-  cmake_parse_arguments(find_qt "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-  # Do not use versionless targets in the first step to avoid Qt::Core being clobbered by later opportunistic
-  # find_package runs
-  set(QT_NO_CREATE_VERSIONLESS_TARGETS TRUE)
-
-  message(DEBUG "Attempting to find Qt 6")
-  find_package(
-    Qt6
-    COMPONENTS Core
-    REQUIRED)
-
-  # Enable versionless targets for the remaining Qt components
-  set(QT_NO_CREATE_VERSIONLESS_TARGETS FALSE)
-
-  set(qt_components ${find_qt_COMPONENTS})
-  if(OS_WINDOWS)
-    list(APPEND qt_components ${find_qt_COMPONENTS_WIN})
-  elseif(OS_MACOS)
-    list(APPEND qt_components ${find_qt_COMPONENTS_MAC})
-  else()
-    list(APPEND qt_components ${find_qt_COMPONENTS_LINUX})
-  endif()
-  message(DEBUG "Trying to find Qt components ${qt_components}...")
-
-  find_package(Qt6 REQUIRED ${qt_components})
-
-  list(APPEND qt_components Core)
-
-  if("Gui" IN_LIST find_qt_COMPONENTS_LINUX)
-    list(APPEND qt_components "GuiPrivate")
-  endif()
-
-  # Check for versionless targets of each requested component and create if necessary
-  foreach(component IN LISTS qt_components)
-    message(DEBUG "Checking for target Qt::${component}")
-    if(NOT TARGET Qt::${component} AND TARGET Qt6::${component})
-      add_library(Qt::${component} INTERFACE IMPORTED)
-      set_target_properties(Qt::${component} PROPERTIES INTERFACE_LINK_LIBRARIES Qt6::${component})
-    endif()
-    set_property(TARGET Qt::${component} PROPERTY INTERFACE_COMPILE_FEATURES "")
-  endforeach()
-
-endmacro()
-
 # check_uuid: Helper function to check for valid UUID
 function(check_uuid uuid_string return_value)
   set(valid_uuid TRUE)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This is a port of https://github.com/obsproject/obs-studio/pull/9263 (https://github.com/obsproject/obs-studio/commit/9d611a064f042cec6cba1d64818c8e810ebc4744).

This does not remove `find_qt`, but just forces it to Qt 6 for now.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

We no longer support building OBS Studio with Qt 5.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I haven't tested this, This is a port of an existing commit, which has been tested.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
