### PR TITLE
powershell: Fixes Inno Setup installation and iscc lookup

### DIFF
--- a/.github/scripts/.Wingetfile
+++ b/.github/scripts/.Wingetfile
@@ -1,2 +1,2 @@
 package 'cmake', path: 'Cmake\bin', bin: 'cmake'
-package 'innosetup', path: 'Inno Setup 6', bin: 'iscc'
+package 'Inno Setup', path: 'Inno Setup 6', bin: 'iscc'

--- a/.github/scripts/utils.pwsh/Install-BuildDependencies.ps1
+++ b/.github/scripts/utils.pwsh/Install-BuildDependencies.ps1
@@ -22,6 +22,7 @@ function Install-BuildDependencies {
         'x64' = ${Env:ProgramFiles}
         'x86' = ${Env:ProgramFiles(x86)}
         'arm64' = ${Env:ProgramFiles(arm)}
+        'appdata-x64' = ${Env:LOCALAPPDATA}+"\Programs"
     }
 
     $Paths = $Env:Path -split [System.IO.Path]::PathSeparator


### PR DESCRIPTION
Inno Setup package name in .WingetFile is wrong and doesn't install. 
Inno Setup installs in LocalAppData\Programs which 
Install-BuildDependencies does not look at.

### Description

Updates build and packaging powershell scripts for Windows.

* Fixes Inno Setup winget package name in .WingetFile
* Fixes Inno Setup install location in Install-BuildDependencies.ps1

### Motivation and Context

Inno Setup's winget package name is incorrect in winget which results in failing
to install it. Used `winget search` to search for the package and found the package by JRSoftware.

Additionally, Inno Setup installs under `[LOCALAPPDATA]\Programs\Inno Setup 6`, 
so iscc is never found by Get-Program as the $Prefixes array in the `Install-BuildDependencies.ps1`
does not contain any AppData directory as viable install locations. This PR only deals with Inno's
`[LOCALAPPDATA]\Programs` install directory, but, since many programs these days use AppData
which requires less permissions than ProgramFiles, it might be better to add more options.

### How Has This Been Tested?

Both changes were tested on Windows 11 through the integrated powershell terminal on VSCode.
In both cases, the changes allowed the scripts to install, find and run Inno Setup and at the end
the -BuildInstaller switch actually produced an Installer.

### Types of changes
- - Bug fix (non-breaking change which fixes an issue)
- - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
