### PR TITLE
cmake: Fix default installation directory for Windows

### DIFF
--- a/cmake/windows/defaults.cmake
+++ b/cmake/windows/defaults.cmake
@@ -10,7 +10,7 @@ include(buildspec)
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(
     CMAKE_INSTALL_PREFIX
-    "$ENV{APPDATA}/obs-studio/plugins"
+    "$ENV{ALLUSERSPROFILE}/obs-studio/plugins"
     CACHE STRING
     "Default plugin installation directory"
     FORCE


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fix the wrong default value in cmake script.


### Motivation and Context

The default installation for Windows in cmake script is wrong. OBS won't load plugin from there.

from

https://github.com/obsproject/obs-studio/blob/31.0.1/UI/window-basic-main.cpp#L201
```int ret = GetProgramDataPath(base_module_dir, sizeof(base_module_dir), "obs-studio/plugins/%module%");```
https://github.com/obsproject/obs-studio/blob/31.0.1/UI/window-basic-main.cpp#L211
```string path = base_module_dir;```
https://github.com/obsproject/obs-studio/blob/31.0.1/UI/window-basic-main.cpp#L231
```obs_add_module_path((path + "/bin/64bit").c_str(), (path + "/data").c_str());```


### How Has This Been Tested?

My plugin works.


### Types of changes

Bug fix


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
