### PR TITLE
cmake: Adjust macOS SDK detection

### DIFF
--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -15,22 +15,48 @@ include(compiler_common)
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fopenmp-simd>")
 
 # Ensure recent enough Xcode and platform SDK
-set(_obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
-set(_obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
-message(DEBUG "macOS SDK Path: ${CMAKE_OSX_SYSROOT}")
-string(REGEX MATCH ".+/MacOSX.platform/Developer/SDKs/MacOSX([0-9]+\\.[0-9])+\\.sdk$" _ ${CMAKE_OSX_SYSROOT})
-set(_obs_macos_current_sdk ${CMAKE_MATCH_1})
-message(DEBUG "macOS SDK version: ${_obs_macos_current_sdk}")
-if(_obs_macos_current_sdk VERSION_LESS _obs_macos_minimum_sdk)
-  message(
-    FATAL_ERROR
-    "Your macOS SDK version (${_obs_macos_current_sdk}) is too low. "
-    "The macOS ${_obs_macos_minimum_sdk} SDK (Xcode ${_obs_macos_minimum_xcode}) is required to build OBS."
+function(check_sdk_requirements)
+  set(obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
+  set(obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
+  execute_process(
+    COMMAND xcrun --sdk macosx --show-sdk-platform-version
+    OUTPUT_VARIABLE obs_macos_current_sdk
+    RESULT_VARIABLE result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-endif()
-unset(_obs_macos_current_sdk)
-unset(_obs_macos_minimum_sdk)
-unset(_obs_macos_minimum_xcode)
+  if(NOT result EQUAL 0)
+    message(
+      FATAL_ERROR
+      "Failed to fetch macOS SDK version. "
+      "Ensure that the macOS SDK is installed and that xcode-select points at the Xcode developer directory."
+    )
+  endif()
+  message(DEBUG "macOS SDK version: ${obs_macos_current_sdk}")
+  if(obs_macos_current_sdk VERSION_LESS obs_macos_minimum_sdk)
+    message(
+      FATAL_ERROR
+      "Your macOS SDK version (${obs_macos_current_sdk}) is too low. "
+      "The macOS ${obs_macos_minimum_sdk} SDK (Xcode ${obs_macos_minimum_xcode}) is required to build OBS."
+    )
+  endif()
+  execute_process(COMMAND xcrun --find xcodebuild OUTPUT_VARIABLE obs_macos_xcodebuild RESULT_VARIABLE result)
+  if(NOT result EQUAL 0)
+    message(
+      FATAL_ERROR
+      "Xcode was not found. "
+      "Ensure you have installed Xcode and that xcode-select points at the Xcode developer directory."
+    )
+  endif()
+  message(DEBUG "Path to xcodebuild binary: ${obs_macos_xcodebuild}")
+  if(XCODE_VERSION VERSION_LESS obs_macos_minimum_xcode)
+    message(
+      FATAL_ERROR
+      "Your Xcode version (${XCODE_VERSION}) is too low. Xcode ${obs_macos_minimum_xcode} is required to build OBS."
+    )
+  endif()
+endfunction()
+
+check_sdk_requirements()
 
 # Enable dSYM generator for release builds
 string(APPEND CMAKE_C_FLAGS_RELEASE " -g")


### PR DESCRIPTION
### Description
Follow OBS's Master branch : https://github.com/obsproject/obs-studio/blob/master/cmake/macos/compilerconfig.cmake
Fix errors when macOS SDK is not detected when using cmake 4.0.0+


### Motivation and Context
Developer using cmake 4.0.0 cannot compile plugins and get an error that the macos Version is too low.
The previous SDK detection process return an empty value for the version of the SDK

### How Has This Been Tested?
Confirmed it solved the problem as part of the developement of the [DistroAV plugin](https://github.com/DistroAV/DistroAV/)

### Types of changes
Bug fixs for user on MacOS and Cmake 4.0.0+

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
