### PR TITLE
CI: Enhance/Fix macOS build scripts with Xcode and SDK auto-detecting and logging

### DIFF
--- a/.github/scripts/build-macos
+++ b/.github/scripts/build-macos
@@ -110,6 +110,15 @@ build() {
     typeset -gx CODESIGN_TEAM="$(print "${CODESIGN_IDENT}" | /usr/bin/sed -En 's/.+\((.+)\)/\1/p')"
   }
 
+  log_group "Xcode and SDK Info"
+  export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+  export DEVELOPER_DIR="/Applications/Xcode_16.1.0.app/Contents/Developer"
+
+  xcodebuild -version
+  xcodebuild -showsdks
+  xcode-select -p
+  xcrun --show-sdk-version
+
   log_group "Configuring ${product_name}..."
   cmake -S ${project_root} ${cmake_args}
 


### PR DESCRIPTION
### Description
Updates CI, macOS script with Xcode and SDK auto-detecting and logging.

Changes include:
- Added logging for information about Xcode and SDK version used to build for macOS.
- Added auto-detect for Xcode SDK.
- Setted developer directory for Xcode.

Fixes #146 .

### Motivation and Context
macOS build process failed do to the macOS SDK version is not being detected due to the build process using an incorrect path.

### How Has This Been Tested?
CI was run and completed successfully. [CI run](https://github.com/ArckramKreator/obs-plugintemplate/actions/runs/14832587910).
macOS test of the build its needed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
