### PR TITLE
Fix/typos and variable name

### DIFF
--- a/.github/actions/package-plugin/action.yaml
+++ b/.github/actions/package-plugin/action.yaml
@@ -90,7 +90,7 @@ runs:
           --target ubuntu-${{ inputs.target }}
           --config ${{ inputs.config }}
         )
-        if (( ${+RUNNER_DEBUG} )) build_args+=(--debug)
+        if (( ${+RUNNER_DEBUG} )) package_args+=(--debug)
 
         if [[ '${{ inputs.package }}' == 'true' ]] package_args+=(--package)
 

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -94,7 +94,7 @@ function(_setup_obs_studio)
     COMMAND_ERROR_IS_FATAL ANY
     OUTPUT_QUIET
   )
-  message(STATUS "Build ${label} (Reelase - ${arch}) - done")
+  message(STATUS "Build ${label} (Release - ${arch}) - done")
 
   message(STATUS "Install ${label} (${arch})")
   execute_process(


### PR DESCRIPTION
### Description

- Fix undefined variable `build_args` to `package_args` in Ubuntu packaging step of package-plugin action. The `--debug` flag was being appended to a non-existent variable instead of the `package_args` array that is passed to the packaging script.
- Fix typo "Reelase" to "Release" in buildspec_common.cmake status message.


### Motivation and Context

Found these issues while working on adding InnoSetup installer support to a plugin project based on this template.
1. In the Ubuntu packaging step of package-plugin/action.yaml, --debug is appended to an undefined variable build_args instead of package_args. The macOS step in the same file correctly uses package_args.
2. A typo "Reelase" in buildspec_common.cmake status message.

### How Has This Been Tested?

- Verified by reading the source: build_args is never declared in the run: block of the Ubuntu packaging step, nor is it accessible from other steps (each run: block executes in a separate shell process in GitHub Actions)
- Confirmed the macOS packaging step in the same file uses package_args+=(--debug) as the correct reference implementation
- Searched the entire repository for all occurrences of build_args to rule out any shared state or external definition
- Verified that no errors occur when running GitHub Actions workflows
  - https://github.com/semnil/MixTrack2Source/actions/runs/23697818237


### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)


### Checklist:

- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
